### PR TITLE
#5: [Add]: 검색 페이지 마크업

### DIFF
--- a/public/map.svg
+++ b/public/map.svg
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500px"
+   height="500px"
+   viewBox="0 0 500 500"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="map.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <defs
+     id="defs1537">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 250 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="500 : 250 : 1"
+       inkscape:persp3d-origin="250 : 166.66667 : 1"
+       id="perspective2132" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.95182332"
+     inkscape:cx="219.7976"
+     inkscape:cy="263.72627"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     inkscape:window-width="1252"
+     inkscape:window-height="814"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid2111" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1540">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="레이어 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:45;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 206,450 100,-50 140,50 V 110 L 306,50 206,100 56,50 v 350 z"
+       id="path2117"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:45;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 206,100 V 450 L 306,400 V 50"
+       id="path2130" />
+  </g>
+</svg>

--- a/public/question.svg
+++ b/public/question.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500px"
+   height="500px"
+   viewBox="0 0 500 500"
+   version="1.1"
+   id="SVGRoot"
+   sodipodi:docname="question.svg"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)">
+  <defs
+     id="defs833" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.0770646"
+     inkscape:cx="220.23277"
+     inkscape:cy="248.39014"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="true"
+     inkscape:window-width="1252"
+     inkscape:window-height="814"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1407" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata836">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="레이어 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:none;stroke:#000000;stroke-width:45;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none"
+       id="path1427"
+       cx="250.00095"
+       cy="250.00095"
+       r="224.99994" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:45;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;paint-order:normal"
+       d="m 180,190 c 0,-100 150,-80 150,0 0,80 -80,80 -80,80 v 50"
+       id="path1429"
+       sodipodi:nodetypes="czcc" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:142.302;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect1517"
+       width="40"
+       height="50"
+       x="230"
+       y="350" />
+  </g>
+</svg>

--- a/public/search.svg
+++ b/public/search.svg
@@ -1,7 +1,5 @@
 <svg
 	xmlns="http://www.w3.org/2000/svg"
-	width="500px"
-	height="500px"
 	viewBox="0 0 500 500"
 	version="1.1"
 	id="SVGRoot"

--- a/public/search.svg
+++ b/public/search.svg
@@ -1,0 +1,32 @@
+<svg
+	xmlns="http://www.w3.org/2000/svg"
+	width="500px"
+	height="500px"
+	viewBox="0 0 500 500"
+	version="1.1"
+	id="SVGRoot"
+>
+  <g>
+    <g
+			transform="matrix(1.0565857,-1.0565857,1.0565857,1.0565857,-261.81588,261.62925)"
+		>
+      <ellipse
+				style="fill:none;stroke:#000000;stroke-width:19.0674;stroke-linecap:square"
+				id="path1407"
+				cx="250"
+				cy="200"
+				rx="115.46629"
+				ry="115.4663"
+			/>
+      <rect
+				style="fill:none;stroke:#000000;stroke-width:18.0656;stroke-linecap:square"
+				id="rect1409"
+				width="11.93442"
+				height="102.4373"
+				x="244.03281"
+				y="-421.47009"
+				transform="scale(1,-1)"
+			/>
+    </g>
+  </g>
+</svg>

--- a/src/components/IconHolder/IconHolder.module.scss
+++ b/src/components/IconHolder/IconHolder.module.scss
@@ -1,0 +1,5 @@
+.container {
+	.icon {
+		object-fit: fill;
+	}
+}

--- a/src/components/IconHolder/IconHolder.tsx
+++ b/src/components/IconHolder/IconHolder.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import $ from "./IconHolder.module.scss";
+
+type IconHolderProps = {
+	iconPath: string;
+	width: string;
+	height?: string;
+};
+
+export const IconHolder: React.FC<IconHolderProps> = (
+	props: IconHolderProps
+) => {
+	return (
+		<div className={$.container}>
+			<img
+				className={$.icon}
+				src={props.iconPath}
+				alt="image not found"
+				style={{ width: props.width, height: props.height ?? "auto" }}
+			/>
+		</div>
+	);
+};

--- a/src/components/MapInitializer/MapInitializer.module.scss
+++ b/src/components/MapInitializer/MapInitializer.module.scss
@@ -1,0 +1,2 @@
+.container {
+}

--- a/src/components/MapInitializer/MapInitializer.module.scss
+++ b/src/components/MapInitializer/MapInitializer.module.scss
@@ -1,2 +1,5 @@
 .container {
+	#map {
+		border: none;
+	}
 }

--- a/src/components/MapInitializer/MapInitializer.tsx
+++ b/src/components/MapInitializer/MapInitializer.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import $ from "./MapInitializer.module.scss";
+
+declare global {
+	interface Window {
+		kakao: any;
+	}
+}
+
+const MapInitializer: React.FC<{}> = (props: {}) => {
+	React.useEffect(() => {
+		const container = document.getElementById("map");
+		const options = {
+			center: new window.kakao.maps.LatLng(33.450701, 126.570667),
+			level: 3,
+		};
+
+		const map = new window.kakao.maps.Map(container, options);
+	}, []);
+
+	return (
+		<div className={$.container}>
+			<div
+				id="map"
+				style={{ width: "100vw", height: "calc(100vh - 75px)" }}
+			></div>
+		</div>
+	);
+};
+
+export default MapInitializer;

--- a/src/components/MapInitializer/MapInitializer.tsx
+++ b/src/components/MapInitializer/MapInitializer.tsx
@@ -9,7 +9,7 @@ declare global {
 
 const MapInitializer: React.FC<{}> = (props: {}) => {
 	React.useEffect(() => {
-		const container = document.getElementById("map");
+		const container = document.getElementById($.map);
 		const options = {
 			center: new window.kakao.maps.LatLng(33.450701, 126.570667),
 			level: 3,
@@ -21,7 +21,7 @@ const MapInitializer: React.FC<{}> = (props: {}) => {
 	return (
 		<div className={$.container}>
 			<div
-				id="map"
+				id={$.map}
 				style={{ width: "100vw", height: "calc(100vh - 75px)" }}
 			></div>
 		</div>

--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -1,0 +1,14 @@
+.container {
+	width: 100%;
+	height: 75px;
+	box-shadow: 0px 3px 10px #00000020;
+
+	display: flex;
+	align-items: center;
+
+	.logo {
+		margin-left: 50px;
+		font-size: 50px;
+		font-weight: 900;
+	}
+}

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -8,7 +8,7 @@ type NavBarProps = {};
 export const NavBar: React.FC<NavBarProps> = (props: NavBarProps) => {
 	return (
 		<nav className={$.container}>
-			<span className={$.logo}>Ondolbang</span>
+			<a href="/"><span className={$.logo}>Ondolbang</span></a>
 			<SearchBar></SearchBar>
 		</nav>
 	);

--- a/src/components/NavBar/NavBar.tsx
+++ b/src/components/NavBar/NavBar.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import $ from "./NavBar.module.scss";
+
+import { SearchBar } from "@components/SearchBar/SearchBar";
+
+type NavBarProps = {};
+
+export const NavBar: React.FC<NavBarProps> = (props: NavBarProps) => {
+	return (
+		<nav className={$.container}>
+			<span className={$.logo}>Ondolbang</span>
+			<SearchBar></SearchBar>
+		</nav>
+	);
+};

--- a/src/components/SearchBar/SearchBar.module.scss
+++ b/src/components/SearchBar/SearchBar.module.scss
@@ -1,0 +1,22 @@
+.container {
+	// border: 1px solid black;
+	background-color: #f8f8f8;
+	border-radius: 10px;
+	padding: 12px 15px;
+	display: flex;
+	align-items: center;
+	position: absolute;
+	right: 40px;
+
+	.input {
+		border: none;
+		display: inline;
+		font-size: 1.25rem;
+		background-color: transparent;
+		margin-left: 20px;
+
+		&:focus {
+			outline: none;
+		}
+	}
+}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import $ from "./SearchBar.module.scss";
+
+import { IconHolder } from "@components/IconHolder/IconHolder";
+
+type SearchBarProps = {};
+
+export const SearchBar: React.FC<SearchBarProps> = (props: SearchBarProps) => {
+	return (
+		<div className={$.container}>
+			<IconHolder
+				iconPath="/search.svg"
+				width="30px"
+				height="30px"
+			></IconHolder>
+			<input className={$.input} type="text" placeholder="input here"/>
+		</div>
+	);
+};

--- a/src/components/SideBar/SearchResultIndicator/SearchResultIndicator.module.scss
+++ b/src/components/SideBar/SearchResultIndicator/SearchResultIndicator.module.scss
@@ -1,0 +1,41 @@
+@use "@styles/mixins.scss" as *;
+
+.container {
+	width: 100%;
+	height: 100%;
+	color: #e5e5e5;
+	font-size: 1.25rem;
+	@include flex_center_vertical;
+
+	.resolver_container {
+		display: flex;
+		font-size: 1rem;
+		margin-bottom: 10px;
+
+		.resolver_wrapper {
+			overflow: hidden;
+			display: inline-block;
+			height: 1rem;
+			margin-right: 8px;
+
+			scroll-snap-type: y mandatory;
+			scroll-behavior: smooth;
+
+			& > div {
+				color: #f88;
+				scroll-snap-align: center;
+				@include flex_center;
+				justify-content: flex-end;
+			}
+		}
+	}
+
+	.result_num_container {
+		font-size: 1.725rem;
+
+		.number {
+			color: #f8f8f8;
+			text-decoration: underline;
+		}
+	}
+}

--- a/src/components/SideBar/SearchResultIndicator/SearchResultIndicator.tsx
+++ b/src/components/SideBar/SearchResultIndicator/SearchResultIndicator.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import $ from "./SearchResultIndicator.module.scss";
+
+type SearchResultIndicatorProps = {
+	num: number;
+	filters?: [string, string][]; // [필터이름, 필터내용], [...]
+};
+
+export const SearchResultIndicator: React.FC<SearchResultIndicatorProps> = (
+	props: SearchResultIndicatorProps
+) => {
+	const searchFilters: [string, string][] = props.filters ?? [
+		["조건1", "내용1"],
+		["조건2", "조금조금조금조금 긴 내용2"],
+		["조건3", "내용3"],
+		["조건4", "내용4"],
+	];
+	const staticLabel = "의 검색결과";
+
+	const rotateRef = React.useRef<HTMLDivElement>(null);
+	const [idx, setIdx] = React.useState<number>(1);
+
+	React.useEffect(() => {
+		const elem = rotateRef.current;
+		let tick: any;
+		if (elem !== undefined && elem !== null) {
+			tick = setInterval(() => {
+				elem.scrollTop = idx === 0 ? 0 : elem.scrollTop + 20;
+				setIdx((idx + 1) % searchFilters.length);
+			}, 1500);
+		}
+
+		return () => clearInterval(tick);
+	});
+
+	return (
+		<div className={$.container}>
+			<div className={$.resolver_container}>
+				<div ref={rotateRef} className={$.resolver_wrapper}>
+					{searchFilters.map((entry, i) => (
+						<div key={i}>{`${
+							entry[0].length < 6 ? entry[0] : entry[0].substr(0, 6) + "..."
+						}: ${
+							entry[1].length < 6 ? entry[1] : entry[1].substr(0, 6) + "..."
+						}`}</div>
+					))}
+				</div>
+				<div>의 검색결과</div>
+			</div>
+
+			<div className={$.result_num_container}>
+				총 <span className={$.number}>{props.num}</span>건
+			</div>
+		</div>
+	);
+};

--- a/src/components/SideBar/SearchResultItem/SearchResultItem.module.scss
+++ b/src/components/SideBar/SearchResultItem/SearchResultItem.module.scss
@@ -1,0 +1,37 @@
+.container {
+
+	.data_name {
+		padding: 3px;
+		margin-bottom: 15px;
+		font-size: 1.25rem;
+		font-weight: 600;
+		border-bottom: 2px solid #111;
+		display: flex;
+		align-items: center;
+		position: relative;
+
+		.data_name_icons {
+			position: absolute;
+			top: 0px;
+			right: 0px;
+			display: flex;
+
+			& > div > img {
+				margin-left: 8px;
+			}
+		}
+	}
+
+	.data_row {
+		font-size: 0.8rem;
+		color: #888;
+		margin-top: 8px;
+		display: flex;
+		align-items: center;
+
+		& > div > img {
+			opacity: 0.5;
+			margin-left: 8px;
+		}
+	}
+}

--- a/src/components/SideBar/SearchResultItem/SearchResultItem.tsx
+++ b/src/components/SideBar/SearchResultItem/SearchResultItem.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import $ from "./SearchResultItem.module.scss";
+
+import { IconHolder } from "@components/IconHolder/IconHolder";
+
+type SearchResultItemProps = {
+	name: string;
+	data: [number, number][]; // [PBCT_NO, PLNM_NO]: 공매번호, 공고번호
+};
+
+export const SearchResultItem: React.FC<SearchResultItemProps> = (
+	props: SearchResultItemProps
+) => {
+	return (
+		<div className={$.container}>
+			<div className={$.data_name}>
+				<span>{props.name}</span>
+				<div className={$.data_name_icons}>
+					<IconHolder iconPath="question.svg" width="24px" height="24px"></IconHolder>
+					<IconHolder iconPath="map.svg" width="24px" height="24px"></IconHolder>
+				</div>
+			</div>
+			{props.data.map((entry, i) => (
+				<div key={i} className={$.data_row}>
+					<span>공매번호: {entry[0]} / 공고번호: {entry[1]}</span>
+					<IconHolder iconPath="question.svg" width="12px"></IconHolder>
+				</div>
+			))}
+		</div>
+	);
+};

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -1,0 +1,15 @@
+.container {
+	width: 30vw;
+	max-width: 500px;
+	background-color: #fff;
+	position: absolute;
+	left: 0px;
+	box-shadow: 10px 0 5px -5px #00000020;
+	z-index: 9;
+
+	.result_summary {
+		width: 100%;
+		height: 200px;
+		background-color: #444;
+	}
+}

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -6,10 +6,18 @@
 	left: 0px;
 	box-shadow: 10px 0 5px -5px #00000020;
 	z-index: 9;
+	overflow: auto;
 
 	.result_summary {
 		width: 100%;
 		height: 200px;
 		background-color: #444;
+	}
+
+	.result_wrapper {
+		margin: 25px;
+		padding: 25px;
+		background-color: #f8f8f8;
+		border-radius: 8px;
 	}
 }

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -1,14 +1,16 @@
 $width: 30vw;
+$min-width: 350px;
 $z-index: 9;
 $triangle-size: 8px;
+$toggler-left: max(#{$width}, #{$min-width});
 
 .toggler_container {
 	width: 24px;
 	height: 80px;
 	background-color: #fff;
-	position: fixed;
+	position: absolute;
 	top: 50%;
-	left: $width;
+	left: $toggler-left;
 	z-index: $z-index;
 	border-radius: 0px 8px 8px 0px;
 	cursor: pointer;
@@ -27,7 +29,7 @@ $triangle-size: 8px;
 	}
 
 	&.toggler_hidden {
-		transform: translateX(calc(#{$width} * -1 * 0.99));
+		transform: translateX(calc(#{$toggler-left} * -1 * 0.99));
 
 		.triangle {
 			transform: scaleX(-1);
@@ -37,6 +39,7 @@ $triangle-size: 8px;
 
 .container {
 	width: $width;
+	min-width: $min-width;
 	max-width: 500px;
 	background-color: #fff;
 	position: absolute;

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -1,17 +1,64 @@
+$width: 30vw;
+$z-index: 9;
+$triangle-size: 8px;
+
+.toggler_container {
+	width: 24px;
+	height: 80px;
+	background-color: #fff;
+	position: fixed;
+	top: 50%;
+	left: $width;
+	z-index: $z-index;
+	border-radius: 0px 8px 8px 0px;
+	cursor: pointer;
+	transition: transform 0.3s ease;
+
+	.triangle {
+		position: absolute;
+		top: calc(50% - #{$triangle-size});
+		left: calc(50% - #{$triangle-size} / 2);
+		width: 0px;
+		height: 0px;
+		border-left: 0px;
+		border-top: $triangle-size solid transparent;
+		border-bottom: $triangle-size solid transparent;
+		border-right: $triangle-size solid black;
+	}
+
+	&.toggler_hidden {
+		transform: translateX(calc(#{$width} * -1 * 0.99));
+
+		.triangle {
+			transform: scaleX(-1);
+		}
+	}
+}
+
 .container {
-	width: 30vw;
+	width: $width;
 	max-width: 500px;
 	background-color: #fff;
 	position: absolute;
 	left: 0px;
 	box-shadow: 10px 0 5px -5px #00000020;
-	z-index: 9;
+	z-index: $z-index;
 	overflow: auto;
+	transition: transform 0.3s ease;
+
+	&.hidden {
+		transform: translateX(-99%);
+
+		& .result_indicator {
+			background-color: #fff;
+		}
+	}
 
 	.result_indicator {
 		width: 100%;
 		height: 200px;
 		background-color: #444;
+		transition: background-color 0.3s ease;
 	}
 
 	.result_wrapper {

--- a/src/components/SideBar/SideBar.module.scss
+++ b/src/components/SideBar/SideBar.module.scss
@@ -8,7 +8,7 @@
 	z-index: 9;
 	overflow: auto;
 
-	.result_summary {
+	.result_indicator {
 		width: 100%;
 		height: 200px;
 		background-color: #444;

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import $ from "./SideBar.module.scss";
 
 import { SearchResultItem } from "@components/SideBar/SearchResultItem/SearchResultItem";
+import { SearchResultIndicator } from "@components/SideBar/SearchResultIndicator/SearchResultIndicator";
 
 type SideBarProps = {
 	navHeight: string;
@@ -37,13 +38,15 @@ export const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
 				top: props.navHeight,
 			}}
 		>
-			<div className={$.result_summary}></div>
+			<div className={$.result_indicator}>
+				<SearchResultIndicator num={dataPoly.length}></SearchResultIndicator>
+			</div>
 
-				{dataPoly.map((data, i) => (
-					<div className={$.result_wrapper}>
-						<SearchResultItem key={i} {...data}></SearchResultItem>
-					</div>
-				))}
+			{dataPoly.map((data, i) => (
+				<div key={i} className={$.result_wrapper}>
+					<SearchResultItem {...data}></SearchResultItem>
+				</div>
+			))}
 		</div>
 	);
 };

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import $ from "./SideBar.module.scss";
+
+type SideBarProps = {
+	navHeight: string;
+};
+
+export const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
+	return (
+		<div
+			className={$.container}
+			style={{ height: `calc(100% - ${props.navHeight})`, top: props.navHeight }}
+		>
+			<div className={$.result_summary}>
+			</div>
+		</div>
+	);
+};

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -1,18 +1,49 @@
 import * as React from "react";
 import $ from "./SideBar.module.scss";
 
+import { SearchResultItem } from "@components/SideBar/SearchResultItem/SearchResultItem";
+
 type SideBarProps = {
 	navHeight: string;
 };
 
 export const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
+	const testName = "테스트 검색결과";
+	const dataPairs: [number, number][] = [
+		[123456, 123967],
+		[123456, 123967],
+		[123456, 123967],
+		[123456, 123967],
+	];
+	const dataMono = {
+		name: testName,
+		data: dataPairs,
+	};
+
+	const dataPoly = [
+		JSON.parse(JSON.stringify(dataMono)),
+		JSON.parse(JSON.stringify(dataMono)),
+		JSON.parse(JSON.stringify(dataMono)),
+		JSON.parse(JSON.stringify(dataMono)),
+		JSON.parse(JSON.stringify(dataMono)),
+		JSON.parse(JSON.stringify(dataMono)),
+	];
+
 	return (
 		<div
 			className={$.container}
-			style={{ height: `calc(100% - ${props.navHeight})`, top: props.navHeight }}
+			style={{
+				height: `calc(100% - ${props.navHeight})`,
+				top: props.navHeight,
+			}}
 		>
-			<div className={$.result_summary}>
-			</div>
+			<div className={$.result_summary}></div>
+
+				{dataPoly.map((data, i) => (
+					<div className={$.result_wrapper}>
+						<SearchResultItem key={i} {...data}></SearchResultItem>
+					</div>
+				))}
 		</div>
 	);
 };

--- a/src/components/SideBar/SideBar.tsx
+++ b/src/components/SideBar/SideBar.tsx
@@ -6,6 +6,7 @@ import { SearchResultIndicator } from "@components/SideBar/SearchResultIndicator
 
 type SideBarProps = {
 	navHeight: string;
+	sidebar: "hidden" | "shown";
 };
 
 export const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
@@ -30,23 +31,50 @@ export const SideBar: React.FC<SideBarProps> = (props: SideBarProps) => {
 		JSON.parse(JSON.stringify(dataMono)),
 	];
 
+	const [isHidden, setHidden] = React.useState<boolean>(
+		props.sidebar === "hidden"
+	);
+	const [isTogglerHidden, setTogglerHidden] = React.useState<boolean>(
+		props.sidebar === "hidden"
+	);
+
+	const ref = React.useRef<HTMLDivElement>(null);
+	const togglerRef = React.useRef<HTMLDivElement>(null);
+	const toggle = (e: any) => {
+		setHidden(!isHidden);
+		setTogglerHidden(!isTogglerHidden);
+	};
+
+	let containerClassNames = $.container;
+	if (isHidden) containerClassNames += ` ${$.hidden}`;
+
+	let togglerClassNames = $.toggler_container;
+	if (isTogglerHidden) togglerClassNames += ` ${$.toggler_hidden}`;
+
 	return (
-		<div
-			className={$.container}
-			style={{
-				height: `calc(100% - ${props.navHeight})`,
-				top: props.navHeight,
-			}}
-		>
-			<div className={$.result_indicator}>
-				<SearchResultIndicator num={dataPoly.length}></SearchResultIndicator>
+		<>
+			<div
+				ref={ref}
+				className={containerClassNames}
+				style={{
+					height: `calc(100% - ${props.navHeight})`,
+					top: props.navHeight,
+				}}
+			>
+				<div className={$.result_indicator}>
+					<SearchResultIndicator num={dataPoly.length}></SearchResultIndicator>
+				</div>
+
+				{dataPoly.map((data, i) => (
+					<div key={i} className={$.result_wrapper}>
+						<SearchResultItem {...data}></SearchResultItem>
+					</div>
+				))}
 			</div>
 
-			{dataPoly.map((data, i) => (
-				<div key={i} className={$.result_wrapper}>
-					<SearchResultItem {...data}></SearchResultItem>
-				</div>
-			))}
-		</div>
+			<div onClick={toggle} className={togglerClassNames}>
+				<div className={$.triangle}></div>
+			</div>
+		</>
 	);
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,68 +1,135 @@
-import Head from 'next/head'
+import Head from "next/head";
 import Link from "next/link";
-import $ from '../styles/Home.module.scss'
+import $ from "../styles/Home.module.scss";
 
-const ondolbang = <div className={$.ondolbang}>Ondolbang</div>
-const copy = <div className={$.copy}>주거목적 공매물건 검색은 <span>온돌방</span>에서</div>
-const scrollIcon = <svg className={$.scroll_icon} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="75" height="75"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 13.172l4.95-4.95 1.414 1.414L12 16 5.636 9.636 7.05 8.222z"/></svg>
+const ondolbang = <div className={$.ondolbang}>Ondolbang</div>;
+const copy = (
+	<div className={$.copy}>
+		주거목적 공매물건 검색은 <span>온돌방</span>에서
+	</div>
+);
+const scrollIcon = (
+	<svg
+		className={$.scroll_icon}
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="75"
+		height="75"
+	>
+		<path fill="none" d="M0 0h24v24H0z" />
+		<path d="M12 13.172l4.95-4.95 1.414 1.414L12 16 5.636 9.636 7.05 8.222z" />
+	</svg>
+);
 const view = (
 	<div className={$.view}>
 		{ondolbang}
 		{copy}
 		{scrollIcon}
 	</div>
-)
+);
 
-const pic1 = <div className={$.img}>이미지를 넣을 공간</div>
-const copy1 = <span className={$.subcopy}>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="50" height="50"><path fill="none" d="M0 0h24v24H0z"/><path d="M18.031 16.617l4.283 4.282-1.415 1.415-4.282-4.283A8.96 8.96 0 0 1 11 20c-4.968 0-9-4.032-9-9s4.032-9 9-9 9 4.032 9 9a8.96 8.96 0 0 1-1.969 5.617zm-2.006-.742A6.977 6.977 0 0 0 18 11c0-3.868-3.133-7-7-7-3.868 0-7 3.132-7 7 0 3.867 3.132 7 7 7a6.977 6.977 0 0 0 4.875-1.975l.15-.15z"/></svg>
-간편하게 검색 필터를 설정합니다</span>
+const pic1 = <div className={$.img}>이미지를 넣을 공간</div>;
+const copy1 = (
+	<span className={$.subcopy}>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width="50"
+			height="50"
+		>
+			<path fill="none" d="M0 0h24v24H0z" />
+			<path d="M18.031 16.617l4.283 4.282-1.415 1.415-4.282-4.283A8.96 8.96 0 0 1 11 20c-4.968 0-9-4.032-9-9s4.032-9 9-9 9 4.032 9 9a8.96 8.96 0 0 1-1.969 5.617zm-2.006-.742A6.977 6.977 0 0 0 18 11c0-3.868-3.133-7-7-7-3.868 0-7 3.132-7 7 0 3.867 3.132 7 7 7a6.977 6.977 0 0 0 4.875-1.975l.15-.15z" />
+		</svg>
+		간편하게 검색 필터를 설정합니다
+	</span>
+);
 const view1 = (
-<div className={$.subview}>
-	{pic1}
-	{copy1}
-</div>
-)
+	<div className={$.subview}>
+		{pic1}
+		{copy1}
+	</div>
+);
 
-const pic2 = <div className={$.img}>이미지를 넣을 공간</div>
-const copy2 = <span className={$.subcopy}>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="50" height="50"><path fill="none" d="M0 0h24v24H0z"/><path d="M18.364 17.364L12 23.728l-6.364-6.364a9 9 0 1 1 12.728 0zM12 13a2 2 0 1 0 0-4 2 2 0 0 0 0 4z"/></svg>
-한눈에 입찰정보를 확인합니다</span>
+const pic2 = <div className={$.img}>이미지를 넣을 공간</div>;
+const copy2 = (
+	<span className={$.subcopy}>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width="50"
+			height="50"
+		>
+			<path fill="none" d="M0 0h24v24H0z" />
+			<path d="M18.364 17.364L12 23.728l-6.364-6.364a9 9 0 1 1 12.728 0zM12 13a2 2 0 1 0 0-4 2 2 0 0 0 0 4z" />
+		</svg>
+		한눈에 입찰정보를 확인합니다
+	</span>
+);
 const view2 = (
-<div className={$.subview}>
-	{copy2}
-	{pic2}
-</div>
-)
+	<div className={$.subview}>
+		{copy2}
+		{pic2}
+	</div>
+);
 
-const pic3 = <div className={$.img}>이미지를 넣을 공간</div>
-const copy3 = <span className={$.subcopy}>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="50" height="50"><path fill="none" d="M0 0h24v24H0z"/><path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-1-5h2v2h-2v-2zm2-1.645V14h-2v-1.5a1 1 0 0 1 1-1 1.5 1.5 0 1 0-1.471-1.794l-1.962-.393A3.501 3.501 0 1 1 13 13.355z"/></svg>
-자세한 정보를 확인합니다</span>
+const pic3 = <div className={$.img}>이미지를 넣을 공간</div>;
+const copy3 = (
+	<span className={$.subcopy}>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width="50"
+			height="50"
+		>
+			<path fill="none" d="M0 0h24v24H0z" />
+			<path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-1-5h2v2h-2v-2zm2-1.645V14h-2v-1.5a1 1 0 0 1 1-1 1.5 1.5 0 1 0-1.471-1.794l-1.962-.393A3.501 3.501 0 1 1 13 13.355z" />
+		</svg>
+		자세한 정보를 확인합니다
+	</span>
+);
 const view3 = (
-<div className={$.subview}>
-	{pic3}
-	{copy3}
-</div>
-)
+	<div className={$.subview}>
+		{pic3}
+		{copy3}
+	</div>
+);
 
-const copy4 = <Link href="/search"><a><span className={$.subcopy}>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="50" height="50"><path fill="none" d="M0 0h24v24H0z"/><path d="M18.031 16.617l4.283 4.282-1.415 1.415-4.282-4.283A8.96 8.96 0 0 1 11 20c-4.968 0-9-4.032-9-9s4.032-9 9-9 9 4.032 9 9a8.96 8.96 0 0 1-1.969 5.617zm-2.006-.742A6.977 6.977 0 0 0 18 11c0-3.868-3.133-7-7-7-3.868 0-7 3.132-7 7 0 3.867 3.132 7 7 7a6.977 6.977 0 0 0 4.875-1.975l.15-.15z"/></svg>
-지금 검색하기</span></a></Link>
-const view4 = (
-<div className={$.subview}>
-	{copy4}
-</div>
-)
+const copy4 = (
+	<Link href="/search">
+		<a>
+			<span className={$.subcopy}>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 24 24"
+					width="50"
+					height="50"
+				>
+					<path fill="none" d="M0 0h24v24H0z" />
+					<path d="M18.031 16.617l4.283 4.282-1.415 1.415-4.282-4.283A8.96 8.96 0 0 1 11 20c-4.968 0-9-4.032-9-9s4.032-9 9-9 9 4.032 9 9a8.96 8.96 0 0 1-1.969 5.617zm-2.006-.742A6.977 6.977 0 0 0 18 11c0-3.868-3.133-7-7-7-3.868 0-7 3.132-7 7 0 3.867 3.132 7 7 7a6.977 6.977 0 0 0 4.875-1.975l.15-.15z" />
+				</svg>
+				지금 검색하기
+			</span>
+		</a>
+	</Link>
+);
+const view4 = <div className={$.subview}>{copy4}</div>;
 
 export default function Home() {
-  return (
-    <div className={$.container}>
-			{view}
-			{view1}
-			{view2}
-			{view3}
-			{view4}
-    </div>
-  )
+	return (
+		<>
+			<Head>
+				<script
+					type="text/javascript"
+					src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_APIKEY}&libraries=services,clusterer,drawing`}
+				></script>
+			</Head>
+			<div className={$.container}>
+				{view}
+				{view1}
+				{view2}
+				{view3}
+				{view4}
+			</div>
+		</>
+	);
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -4,11 +4,7 @@ import dynamic from "next/dynamic";
 
 import { NavBar } from "@components/NavBar/NavBar";
 import MapInitializer from "@components/MapInitializer/MapInitializer";
-
-// const MapInitializer = dynamic(
-// 	() => import("@components/MapInitializer/MapInitializer"),
-// 	{ loading: () => <div>loading maps...</div>, ssr: false }
-// );
+import { SideBar } from "@components/SideBar/SideBar";
 
 export default function Search() {
 	return (
@@ -19,8 +15,17 @@ export default function Search() {
 					src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_APIKEY}&libraries=services,clusterer,drawing`}
 				></script>
 			</Head>
-			<NavBar></NavBar>
-			<MapInitializer></MapInitializer>
+			<header>
+				<NavBar></NavBar>
+			</header>
+
+			<main>
+				<MapInitializer></MapInitializer>
+			</main>
+
+			<aside>
+				<SideBar sidebar="shown" navHeight="75px"></SideBar>
+			</aside>
 		</>
 	);
 }

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,3 +1,26 @@
+import Head from "next/head";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+
+import { NavBar } from "@components/NavBar/NavBar";
+import MapInitializer from "@components/MapInitializer/MapInitializer";
+
+// const MapInitializer = dynamic(
+// 	() => import("@components/MapInitializer/MapInitializer"),
+// 	{ loading: () => <div>loading maps...</div>, ssr: false }
+// );
+
 export default function Search() {
-	return <h1>Hello search page</h1>
+	return (
+		<>
+			<Head>
+				<script
+					type="text/javascript"
+					src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_APIKEY}&libraries=services,clusterer,drawing`}
+				></script>
+			</Head>
+			<NavBar></NavBar>
+			<MapInitializer></MapInitializer>
+		</>
+	);
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,0 +1,12 @@
+@mixin flex_center {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
+@mixin flex_center_vertical {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,80 +1,73 @@
 {
-  "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig.json to read more about this file */
-    /* Basic Options */
-    // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */// "lib": [],                                   /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                             /* Allow javascript files to be compiled. */
-    // "checkJs": true,                             /* Report errors in .js files. */
-    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
-    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
-    // "outFile": "./",                             /* Concatenate and emit output to single file. */
-    // "outDir": "./",                              /* Redirect output structure to the directory. */
-    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                           /* Enable project compilation */
-    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
-    // "removeComments": true,                      /* Do not emit comments to output. */
-    // "noEmit": true,                              /* Do not emit outputs. */
-    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
-    "strict": true, /* Enable all strict type-checking options. */// "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                    /* Enable strict null checks. */
-    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-    /* Additional Checks */
-    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-    /* Module Resolution Options */
-    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                             /* List of folders to include type definitions from. */
-    // "types": [],                                 /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */// "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-    /* Source Map Options */
-    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-    /* Advanced Options */
-    "skipLibCheck": true, /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "noEmit": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
+		/* Basic Options */
+		// "incremental": true,                         /* Enable incremental compilation */
+		"target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */, // "lib": [],                                   /* Specify library files to be included in the compilation. */
+		// "allowJs": true,                             /* Allow javascript files to be compiled. */
+		// "checkJs": true,                             /* Report errors in .js files. */
+		// "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+		// "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+		// "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		// "sourceMap": true,                           /* Generates corresponding '.map' file. */
+		// "outFile": "./",                             /* Concatenate and emit output to single file. */
+		// "outDir": "./",                              /* Redirect output structure to the directory. */
+		// "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "composite": true,                           /* Enable project compilation */
+		// "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+		// "removeComments": true,                      /* Do not emit comments to output. */
+		// "noEmit": true,                              /* Do not emit outputs. */
+		// "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+		/* Strict Type-Checking Options */
+		"strict": true /* Enable all strict type-checking options. */, // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,                    /* Enable strict null checks. */
+		// "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+		// "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+		// "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+		// "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+		/* Additional Checks */
+		// "noUnusedLocals": true,                      /* Report errors on unused locals. */
+		// "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+		// "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+		// "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+		// "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+		/* Module Resolution Options */
+		// "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		"baseUrl": "." /* Base directory to resolve non-absolute module names. */,
+		"paths": {
+			"@components/*": ["src/components/*"],
+			"@styles/*": ["src/styles/*"]
+		} /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
+		// "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+		// "typeRoots": [],                             /* List of folders to include type definitions from. */
+		// "types": [],                                 /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */, // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+		// "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+		/* Source Map Options */
+		// "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+		// "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+		// "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+		/* Experimental Options */
+		// "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+		/* Advanced Options */
+		"skipLibCheck": true /* Skip type checking of declaration files. */,
+		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+		"lib": ["dom", "dom.iterable", "esnext"],
+		"allowJs": true,
+		"noEmit": true,
+		"moduleResolution": "node",
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"jsx": "preserve"
+	},
+	"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
#5

- data fetch 없이 기본 뼈대만 구현함
  - 테스트용으로 간단한 데이터를 하드코딩해서 프로퍼티에 넣었음
  - 아마 요청을 보내기 위해 `axios`를 사용할듯

- 카카오맵 api키 보호를 위해 환경변수 사용
  - 이대로 클론해서 실행시키면 제대로 안보임

- `IconHolder` 컴포넌트를 구현해 public 내부의 아이콘을 로드해 React 컴포넌트 형태로 추가함
  - svg아이콘은 외부에서 가져오기보단 직접 그리는 방향으로 생각중

- `NavBar` 컴포넌트에 로고 이미지 대신 텍스트를 사용함
  - 나중에 로고 디자인을 하든 해야할듯(?)
  - ㄴ 어떻게 할지 의견 부탁합니다ㅎ

- 사용자로부터 입력을 받는 `SearchBar` 컴포넌트는 현재 비워둠
  - 추가할 검색 필터를 다시 논의해야할듯

- 검색결과 관련 컴포넌트들은 모두 `SideBar` 디렉토리 안에 모아놓음
  - 이전에 말한 사용했던 검색 필터를 회전시키며 보이는 ui 구현함 -> `SideBar/SearchResultIndicator`
  - 현재 회전 주기는 `1500ms`
  - 이 경우 검색필터 이름과 내용이 너무 길어지면 컨테이너 밖으로 튀어나가므로 각 문자열을 길이 6 기준으로 자르고 뒤에 `...`을 붙임
  - `ex) 너무긴조건이름은이렇게됨 -> 너무긴조건이...`
  - 검색결과가 많아지면 페이지네이션을 쓰게될건데 해당 컴포넌트는 아직 구현안함

- 반응형 디자인은 아직 고려하지 않음
  - desktop-first strategy
  - 디자인의 수치는 `1920 * 1080`을 기준으로 작성됨

![image](https://user-images.githubusercontent.com/61422890/116822831-120d6080-abbc-11eb-8f54-d6b7da21be3d.png)

